### PR TITLE
Link to Twitter "Latest" tab, instead of "Top"

### DIFF
--- a/discuss-on-twitter.php
+++ b/discuss-on-twitter.php
@@ -7,7 +7,7 @@
  * Version: 0.3
  */
 
-/* 
+/*
 *
 * The button itself
 *
@@ -26,10 +26,10 @@ function discuss_on_twitter_button() {
 
 <div class="discuss-on-twitter">
   <?php if($author_handle): ?>
-    
+
   <?php if ($tweet_id) : ?>
     <a class="discuss-on-twitter-button reply-on-twitter" href="https://twitter.com/intent/tweet?in_reply_to=<?php echo $tweet_id; ?>">
-      <span class="dashicons dashicons-twitter"></span> 
+      <span class="dashicons dashicons-twitter"></span>
       Discuss on Twitter
     </a>
      <a class="discuss-on-twitter-button view-reactions" href="https://twitter.com/<?php echo $author_handle; ?>/status/<?php echo urlencode($tweet_id); ?>" target="_twitter-<?php echo $id; ?>">
@@ -37,7 +37,7 @@ function discuss_on_twitter_button() {
     </a>
     <?php else : ?>
       <a class="discuss-on-twitter-button reply-on-twitter" href="https://twitter.com/intent/tweet?url=<?php echo $permalink; ?>&text=@<?php echo $author_handle; ?>">
-      <span class="dashicons dashicons-twitter"></span> 
+      <span class="dashicons dashicons-twitter"></span>
       Discuss on Twitter
     </a>
     <a class="discuss-on-twitter-button view-reactions" href="https://twitter.com/search?q=<?php echo urlencode($permalink); ?>" target="_twitter-<?php echo $id; ?>">
@@ -50,31 +50,31 @@ function discuss_on_twitter_button() {
       View Discussions on Twitter
     </a>
   <?php endif; ?>
- </div>  
+ </div>
 
 
 
 <?php
 }
 
-/* 
+/*
 *
 * Add link to settings page from plugins page
 *
 */
-add_filter( 'plugin_row_meta', 'dot_plugin_row_meta', 10, 2 ); 
-function dot_plugin_row_meta( $links, $file ) {    
+add_filter( 'plugin_row_meta', 'dot_plugin_row_meta', 10, 2 );
+function dot_plugin_row_meta( $links, $file ) {
     if ( plugin_basename( __FILE__ ) == $file ) {
         $row_meta = array(
           'docs'    => '<a href="' . esc_url( '/wp-admin/options-general.php?page=discuss-on-twitter' ) . '" aria-label="' . esc_attr__( 'Docs and Instructions', 'domain' ) . '">' . esc_html__( 'View details', 'domain' ) . '</a>'
         );
- 
+
         return array_merge( $links, $row_meta );
     }
     return (array) $links;
 }
 
-/* 
+/*
 *
 * Settings page for this plugin
 *
@@ -119,7 +119,7 @@ function dot_options_page()
   <?php if (!$wpt_active): ?>
     <a class="button" href="/wp-admin/plugin-install.php?s=WP+to+Twitter&tab=search&type=term" target="_blank">Install WP to Twitter to continue with advanced installation</a>
   <?php endif; ?>
-  
+
   <?php if($wpt_active):?>
 
     <p><span style="background: yellow">WP to Twitter is Active.  Sweet!</span></p>
@@ -146,7 +146,7 @@ function dot_options_page()
 }
 
 
-/* 
+/*
 *
 * Save Tweet ID to DB
 *

--- a/discuss-on-twitter.php
+++ b/discuss-on-twitter.php
@@ -40,13 +40,13 @@ function discuss_on_twitter_button() {
       <span class="dashicons dashicons-twitter"></span>
       Discuss on Twitter
     </a>
-    <a class="discuss-on-twitter-button view-reactions" href="https://twitter.com/search?q=<?php echo urlencode($permalink); ?>" target="_twitter-<?php echo $id; ?>">
+    <a class="discuss-on-twitter-button view-reactions" href="https://twitter.com/search?q=<?php echo urlencode($permalink); ?>&f=live" target="_twitter-<?php echo $id; ?>">
       View Discussion
     </a>
   <?php endif; ?>
 
   <?php else: ?>
-    <a class="discuss-on-twitter-button view-and-reply" href="https://twitter.com/search?q=<?php echo urlencode($permalink); ?>" target="_twitter-<?php echo $id; ?>">
+    <a class="discuss-on-twitter-button view-and-reply" href="https://twitter.com/search?q=<?php echo urlencode($permalink); ?>&f=live" target="_twitter-<?php echo $id; ?>">
       View Discussions on Twitter
     </a>
   <?php endif; ?>

--- a/readme.txt
+++ b/readme.txt
@@ -12,12 +12,12 @@ Use Twitter as a commenting system.
 
 == Description ==
 
-Enable commenting on your posts via Twitter.  
+Enable commenting on your posts via Twitter.
 
 Posts will get a "Reply on Twitter" button, which will prompt visitors to reply to the original tweet about the post, as well as a "View Reactions" button which will link to existing tweets about the post.
 
 Each new post will be auto-tweeted (requires the [WP to Twitter](https://wordpress.org/plugins/wp-to-twitter/) plugin and a [Twitter Developer account](https://developer.twitter.com/)).
- 
+
 == Installation ==
 
 = Simple Installation =
@@ -39,7 +39,7 @@ The advanced installation enables auto-tweeting of new posts from your account a
 The advanced installation builds upon the awesome [WP to Twitter](https://wordpress.org/plugins/wp-to-twitter/) plugin by [Joseph C. Dolson](http://www.joedolson.com/).
 
 After completing the steps for Simple Installation, above, do the following:
- 
+
 1. Install and activate the [WP to Twitter](https://wordpress.org/plugins/wp-to-twitter/) plugin.
 
 2. Set up your [Twitter Developer account](https://developer.twitter.com/) and create a new app for your site.  This may require waiting for approval from Twitter if you are setting up your developer account for the first time.
@@ -55,18 +55,18 @@ For new posts, where tweets are created upon publishing, the "Reply on Twitter" 
 For older posts which do not have a tweet associated with them, the "Reply on Twitter" button will @mention your account, including the link to the post, but will not be formed as a reply to a tweet about the post.
 
 == Screenshots ==
- 
+
 1. Discuss on Twitter button, including Twitter reply pop-up
 2. Basic settings for WP to Twitter, ensuring that "Update when Posts are published" is checked
 3. Individual post settings for WP to Twitter, showing the option to "Tweet" or "Don't Tweet" when a single post is published
- 
+
 == Changelog ==
- 
+
 = 0.1 =
 * Initial release
 
 = 0.2 =
 * Refine behavior of buttons and tighten styles. More clearly separate 'basic installation' from 'advanced installation'.
 
-= 0.3 = 
+= 0.3 =
 * Refine behavior of "discuss" button to go directly to tweet rather than to search, if there is a canonical tweet.


### PR DESCRIPTION
Whenever someone didn't post a specific tweet. I noticed Fred's blog wasn't doing that on his post announcing this thing: https://avc.com/2020/01/funding-friday-make-100-3/

Looking at it closer, I think he might be using an old version of the plugin, or something custom? His link also includes`&src=typed_query` which is not present in this codebase

Plus a whitespace cleanup commit. I'm sorry OK